### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2019 iu_long
+Copyright (c) 2016 Uber Technologies, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Re-add the required original copyright from Uber (https://github.com/yarpc/yab/blob/dev/LICENSE). Since yab-thrift is a fork, the original copyright must be retained.